### PR TITLE
Task#158 - Sticky table header

### DIFF
--- a/FogCarport/src/main/webapp/css/global.css
+++ b/FogCarport/src/main/webapp/css/global.css
@@ -257,8 +257,9 @@
     color: #e5e6e8;
     background-color: #263e63;
     border-color:#384459;
+    position: sticky;
+    top: 0px;
 }
-
 
 /*----------------- ViewOrder.JSP CSS -----------------*/
 


### PR DESCRIPTION
# [Task#158](https://tree.taiga.io/project/maltemagnussen-fog/task/158)
Here is how it looks currently:
![Sticky header](https://i.imgur.com/CVyOzRG.gif)

You can change the distance from the top of the screen by changing the `top` in global.css.
Its default is `top: 0px;`

The trick here is to add the `sticky`-tag to the `th`-element; **NOT** the `thead`-element - as it is currently bugged:  
Explanation can be found on [Stackoverflow](https://stackoverflow.com/a/52008347).