### PR TITLE
Issue#167 - Price formatting

### DIFF
--- a/FogCarport/src/main/webapp/javascript/global.js
+++ b/FogCarport/src/main/webapp/javascript/global.js
@@ -358,9 +358,6 @@ function calculateOperationMarginSuggestedPrice() {
     let suggestedprice = parseFloat(document.getElementById("suggestedretailprice").innerHTML);
     let costprice = parseFloat(document.getElementById("costprice").innerHTML);
     let operationMargin = parseFloat(((suggestedprice / costprice) * 100) - 100).toFixed(1);
-    //console.log("costprice: " + costprice.constructor + costprice);
-    //console.log("suggestedprice: " + suggestedprice.constructor + suggestedprice);
-    //console.log("operationMargin: " + operationMargin.constructor + operationMargin);
     document.getElementById("operationmargin").innerHTML = operationMargin;
 }
 function calculateOperationsMarignVariblePrice() {
@@ -372,9 +369,6 @@ function calculateOperationsMarignVariblePrice() {
     let costprice = document.getElementById("costprice").innerHTML;
 
     let varOperationMargin = parseFloat(((varprice / costprice) * 100) - 100).toFixed(1);
-//    console.log("costprice: " + costprice.constructor + costprice);
-//    console.log("varprice: " + varprice.constructor + varprice);
-//    console.log("varOperationMargin: " + varOperationMargin.constructor + varOperationMargin);
     document.getElementById("varpricemargin").innerHTML = varOperationMargin;
 }
 

--- a/FogCarport/src/main/webapp/javascript/global.js
+++ b/FogCarport/src/main/webapp/javascript/global.js
@@ -355,9 +355,12 @@ function clearShedDimensionsMenu() {
 
 /*----------------- ViewOrder JS -----------------  */
 function calculateOperationMarginSuggestedPrice() {
-    let suggestedprice = document.getElementById("suggestedretailprice").innerHTML;
-    let costprice = document.getElementById("costprice").innerHTML;
+    let suggestedprice = parseFloat(document.getElementById("suggestedretailprice").innerHTML);
+    let costprice = parseFloat(document.getElementById("costprice").innerHTML);
     let operationMargin = parseFloat(((suggestedprice / costprice) * 100) - 100).toFixed(1);
+    //console.log("costprice: " + costprice.constructor + costprice);
+    //console.log("suggestedprice: " + suggestedprice.constructor + suggestedprice);
+    //console.log("operationMargin: " + operationMargin.constructor + operationMargin);
     document.getElementById("operationmargin").innerHTML = operationMargin;
 }
 function calculateOperationsMarignVariblePrice() {
@@ -369,6 +372,9 @@ function calculateOperationsMarignVariblePrice() {
     let costprice = document.getElementById("costprice").innerHTML;
 
     let varOperationMargin = parseFloat(((varprice / costprice) * 100) - 100).toFixed(1);
+    console.log("costprice: " + costprice.constructor + costprice);
+    console.log("varprice: " + varprice.constructor + varprice);
+    console.log("varOperationMargin: " + varOperationMargin.constructor + varOperationMargin);
     document.getElementById("varpricemargin").innerHTML = varOperationMargin;
 }
 

--- a/FogCarport/src/main/webapp/partslist.jsp
+++ b/FogCarport/src/main/webapp/partslist.jsp
@@ -1,5 +1,8 @@
 <!--The following tag is the JSTL tag-->
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!-- JSTL formatNumber tag -->
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>  
+<fmt:setLocale value="da_DK"/>
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 
 <table class="table table-fixed table-bordered mt-5 table-striped">
@@ -37,7 +40,8 @@
                 <td>${material.width}</td>
                 <td>${material.height}</td>
                 <c:if test= "${not empty sessionScope.employee}"> 
-                    <td>${material.price}</td>
+                    <td><span id="singlePriceTOSTRING"><fmt:formatNumber value="${material.price}" type="currency" currencySymbol=""/></span></td>
+                    <p id="singlePrice" hidden> ${material.price}</p>
                 </c:if>
             </tr>
         </c:forEach>

--- a/FogCarport/src/main/webapp/viewOrder.jsp
+++ b/FogCarport/src/main/webapp/viewOrder.jsp
@@ -1,4 +1,6 @@
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>  
+<fmt:setLocale value="da_DK"/>
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <!DOCTYPE html>
 
@@ -63,7 +65,7 @@
     <div>
         <c:choose> 
             <c:when test="${order.status == 'Finalized'}">
-                <p>Ordren er betalt: <span id="paidPrice">${order.price}</span> DKK</p>
+                <p>Ordren er betalt: <span id="paidPrice"><fmt:formatNumber value="${order.price}" type="currency" currencySymbol=""/></span> DKK</p>
             </c:when>
             <c:otherwise>
                 <p>Vejledende salgspris: <span id="suggestedretailprice">${suggestedprice}</span> DKK</p>

--- a/FogCarport/src/main/webapp/viewOrder.jsp
+++ b/FogCarport/src/main/webapp/viewOrder.jsp
@@ -73,7 +73,7 @@
         </c:choose>
 
         <c:if test= "${not empty priceOffer}">
-            <p>Tilbudspris: <span id="priceoffer">${priceOffer}</span> DKK</p>
+            <p>Tilbudspris: <span id="priceoffer"><fmt:formatNumber value="${priceOffer}" type="currency" currencySymbol=""/></span> DKK</p>
             <c:if test= "${not empty sessionScope.employee}"> 
                 <p>Dækningsgrad for tilbudspris: <span id="offerpricemargin"> </span> %</p>
             </c:if>

--- a/FogCarport/src/main/webapp/viewOrder.jsp
+++ b/FogCarport/src/main/webapp/viewOrder.jsp
@@ -89,7 +89,7 @@
                     <input id="varpriceinput" placeholder="Ny pris" name="finalPrice" type="number" min="0">
                     <input type="hidden" name="command" value="viewOrder">  
                     <input type="hidden" name="orderid" value="${order.id}">
-                    <p> Dækningsgrad: <span id="varpricemargin"> </span> %</p>
+                    <p> Dækningsgrad: <span id="varpricemargin"></span>%</p>
                     <button type="submit" class="btn btn-outline-secondary mb-1">Send tilbud</button>
                 </form>
             </div>

--- a/FogCarport/src/main/webapp/viewOrder.jsp
+++ b/FogCarport/src/main/webapp/viewOrder.jsp
@@ -116,9 +116,9 @@
         <form action="FrontController"  class="">
             <input type="hidden" name="command" value="payOrder">
             <input type="hidden" name="orderid" value="${order.id}">
-            <!-- Pay reduced price if exists, else normal price -->
             <c:choose> 
                 <c:when test="${not empty priceOffer}">
+                    <!-- Pay reduced price if exists, else normal price -->
                     <input type="hidden" name="price" value="${priceOffer}">
                 </c:when>
                 <c:otherwise>

--- a/FogCarport/src/main/webapp/viewOrder.jsp
+++ b/FogCarport/src/main/webapp/viewOrder.jsp
@@ -61,6 +61,7 @@
     </tbody>
 </table>
 <hr>
+<!-- Order price and payment information--> 
 <div class="d-flex flex-column pl-5 mt-5 mb-3 infoboxorderview">
     <div>
         <c:choose> 

--- a/FogCarport/src/main/webapp/viewOrder.jsp
+++ b/FogCarport/src/main/webapp/viewOrder.jsp
@@ -83,7 +83,7 @@
 
             <div class="mt-4">
                 <h5>Afgiv tilbud?</h5>
-                <p>Indkøbspris: <span id="costprice">${costprice} </span> DKK</p>
+                <p>Indkøbspris: <span id="costprice">$<fmt:formatNumber value="${costprice}" type="currency" currencySymbol=""/> </span> DKK</p>
                 <form method="POST" action="FrontController">
                     <input id="varpriceinput" placeholder="Ny pris" name="finalPrice" type="number" min="0">
                     <input type="hidden" name="command" value="viewOrder">  

--- a/FogCarport/src/main/webapp/viewOrder.jsp
+++ b/FogCarport/src/main/webapp/viewOrder.jsp
@@ -1,4 +1,6 @@
+<!-- JSTL Tag -->
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!-- JSTL formatNumber tag -->
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>  
 <fmt:setLocale value="da_DK"/>
 <%@page contentType="text/html" pageEncoding="UTF-8"%>

--- a/FogCarport/src/main/webapp/viewOrder.jsp
+++ b/FogCarport/src/main/webapp/viewOrder.jsp
@@ -68,7 +68,7 @@
                 <p>Ordren er betalt: <span id="paidPrice"><fmt:formatNumber value="${order.price}" type="currency" currencySymbol=""/></span> DKK</p>
             </c:when>
             <c:otherwise>
-                <p>Vejledende salgspris: <span id="suggestedretailprice">${suggestedprice}</span> DKK</p>
+                <p>Vejledende salgspris: <span id="suggestedretailprice"><fmt:formatNumber value="${suggestedprice}" type="currency" currencySymbol=""/></span> DKK</p>
             </c:otherwise>
         </c:choose>
 

--- a/FogCarport/src/main/webapp/viewOrder.jsp
+++ b/FogCarport/src/main/webapp/viewOrder.jsp
@@ -84,7 +84,7 @@
 
             <div class="mt-4">
                 <h5>Afgiv tilbud?</h5>
-                <p>Indkøbspris: <span id="costprice">$<fmt:formatNumber value="${costprice}" type="currency" currencySymbol=""/> </span> DKK</p>
+                <p>Indkøbspris: <span id="costprice"><fmt:formatNumber value="${costprice}" type="currency" currencySymbol=""/></span> DKK</p>
                 <form method="POST" action="FrontController">
                     <input id="varpriceinput" placeholder="Ny pris" name="finalPrice" type="number" min="0">
                     <input type="hidden" name="command" value="viewOrder">  
@@ -118,7 +118,7 @@
                 <button type="submit" class="btn btn-outline-secondary mb-1">Betal ordre</button>
             </c:if>
             <c:if test="${not empty sessionScope.employee}">
-                <p>Ved kontant betaling eller betling via bankoverførsel, så bekræft modtagelse af betaling</p>
+                <p>Ved kontant betaling eller betaling via bankoverførsel, så bekræft modtagelse af betaling</p>
                 <button type="submit" class="btn btn-outline-secondary mb-1">Bekræft modtagelse af betaling</button>
             </c:if>
         </form>

--- a/FogCarport/src/main/webapp/viewOrder.jsp
+++ b/FogCarport/src/main/webapp/viewOrder.jsp
@@ -73,38 +73,43 @@
     <div>
         <c:choose> 
             <c:when test="${order.status == 'Finalized'}">
+                <!-- if order is paid -->
                 <p>Ordren er betalt: <span id="paidPriceTOSTRING"><fmt:formatNumber value="${order.price}" type="currency" currencySymbol=""/></span> DKK</p>
                 <p id="paidPrice" hidden> ${order.price}</p>
             </c:when>
             <c:otherwise>
+                <!-- if order is not paid -->
                 <p>Vejledende salgspris: <span id="suggestedretailpriceTOSTRING"><fmt:formatNumber value="${suggestedprice}" type="currency" currencySymbol=""/></span> DKK</p>
                 <p id="suggestedretailprice" hidden> ${suggestedprice}</p>
+
+                <c:if test= "${not empty priceOffer}">
+                    <!-- show offer if exists-->
+                    <p>Tilbudspris: <span id="priceofferTOSTRING"><strong><fmt:formatNumber value="${priceOffer}" type="currency" currencySymbol=""/></span></strong> DKK</p>
+                    <p id="priceoffer" hidden> ${priceOffer}</p>
+                </c:if>
+                <c:if test= "${not empty sessionScope.employee}"> 
+                    <!-- If employee, show margin-->
+                    <p>Dækningsgrad for vejledende salgspris: <span id="operationmargin"></span>%</p>
+                    <c:if test= "${not empty priceOffer && not empty sessionScope.employee}"> 
+                        <p>Dækningsgrad for tilbudspris: <span id="offerpricemargin"> </span>%</p>
+                    </c:if>
+                    <c:if test="${order.status != 'Finalized'}">
+                        <div class="mt-4">
+                            <h5>Afgiv tilbud</h5>
+                            <p>Indkøbspris: <span id="costpriceTOSTRING"><fmt:formatNumber value="${costprice}" type="currency" currencySymbol=""/></span> DKK</p>
+                            <p id="costprice" hidden> ${costprice}</p>
+                            <form method="POST" action="FrontController">
+                                <input id="varpriceinput" placeholder="Ny pris" name="finalPrice" type="number" min="0">
+                                <input type="hidden" name="command" value="viewOrder">  
+                                <input type="hidden" name="orderid" value="${order.id}">
+                                <p> Dækningsgrad: <span id="varpricemargin"></span>%</p>
+                                <button type="submit" class="btn btn-outline-secondary mb-1">Send tilbud</button>
+                            </form>
+                        </div>
+                    </c:if>
+                </c:if>
             </c:otherwise>
         </c:choose>
-
-        <c:if test= "${not empty priceOffer}">
-            <p>Tilbudspris: <span id="priceofferTOSTRING"><fmt:formatNumber value="${priceOffer}" type="currency" currencySymbol=""/></span> DKK</p>
-            <p id="priceoffer" hidden> ${priceOffer}</p>
-            <c:if test= "${not empty sessionScope.employee}"> 
-                <p>Dækningsgrad for tilbudspris: <span id="offerpricemargin"> </span> %</p>
-            </c:if>
-        </c:if>
-        <c:if test= "${not empty sessionScope.employee && order.status != 'Finalized'}"> 
-            <p>Dækningsgrad for vejledende salgspris: <span id="operationmargin"></span>%</p>
-
-            <div class="mt-4">
-                <h5>Afgiv tilbud?</h5>
-                <p>Indkøbspris: <span id="costpriceTOSTRING"><fmt:formatNumber value="${costprice}" type="currency" currencySymbol=""/></span> DKK</p>
-                <p id="costprice" hidden> ${costprice}</p>
-                <form method="POST" action="FrontController">
-                    <input id="varpriceinput" placeholder="Ny pris" name="finalPrice" type="number" min="0">
-                    <input type="hidden" name="command" value="viewOrder">  
-                    <input type="hidden" name="orderid" value="${order.id}">
-                    <p> Dækningsgrad: <span id="varpricemargin"></span>%</p>
-                    <button type="submit" class="btn btn-outline-secondary mb-1">Send tilbud</button>
-                </form>
-            </div>
-        </c:if>
     </div> 
 </div>
 

--- a/FogCarport/src/main/webapp/viewOrder.jsp
+++ b/FogCarport/src/main/webapp/viewOrder.jsp
@@ -80,7 +80,7 @@
             </c:if>
         </c:if>
         <c:if test= "${not empty sessionScope.employee && order.status != 'Finalized'}"> 
-            <p>Dækningsgrad for vejledende salgspris: <span id="operationmargin"> </span> %</p>
+            <p>Dækningsgrad for vejledende salgspris: <span id="operationmargin"></span>%</p>
 
             <div class="mt-4">
                 <h5>Afgiv tilbud?</h5>


### PR DESCRIPTION
# [Issue#167](https://github.com/HrBjarup/Fog-Carport/issues/167)
**EDIT:** Added more screenshots and changes down below!

Added price formatting using JSTL numberFormat

There were a bit of issues with the Javascript related to prices on `ViewOrder.jsp` which were fixed by creating hidden elements and going from there. The main issue here was the `String`-object returned by the Number Formatter had trouble parsing `float`s correctly, and thus displayed not at all or wrongly.
Thanks to @Castau.

## Partslist view (employee)
![image](https://user-images.githubusercontent.com/37186286/58382831-63c01000-7fcf-11e9-8423-c486bee504f4.png)
## ViewOrder.jsp (employee) 
**(old, see comment down below)**
![image](https://user-images.githubusercontent.com/37186286/58382843-8baf7380-7fcf-11e9-8576-288c5dd39ab5.png)
